### PR TITLE
Switch hand-rolled copying to inbuilt clone

### DIFF
--- a/lib/src/callstack.rs
+++ b/lib/src/callstack.rs
@@ -204,10 +204,6 @@ impl CallStack {
         cs
     }
 
-    pub fn new_from(to_copy: &CallStack) -> CallStack {
-        to_copy.clone()
-    }
-
     pub fn get_current_element(&self) -> &Element {
         let thread = self.threads.last().unwrap();
         let cs = &thread.callstack;

--- a/lib/src/callstack.rs
+++ b/lib/src/callstack.rs
@@ -14,6 +14,7 @@ use crate::{
     value::Value,
 };
 
+#[derive(Clone)]
 pub struct Element {
     pub current_pointer: Pointer,
     pub in_expression_evaluation: bool,
@@ -38,21 +39,9 @@ impl Element {
             function_start_in_output_stream: 0,
         }
     }
-
-    fn copy(&self) -> Element {
-        let mut copy = Element::new(
-            self.push_pop_type,
-            self.current_pointer.clone(),
-            self.in_expression_evaluation,
-        );
-        copy.temporary_variables = self.temporary_variables.clone();
-        copy.evaluation_stack_height_when_pushed = self.evaluation_stack_height_when_pushed;
-        copy.function_start_in_output_stream = self.function_start_in_output_stream;
-
-        copy
-    }
 }
 
+#[derive(Clone)]
 pub struct Thread {
     pub callstack: Vec<Element>,
     pub previous_pointer: Pointer,
@@ -148,19 +137,6 @@ impl Thread {
         Ok(thread)
     }
 
-    pub fn copy(&self) -> Thread {
-        let mut copy = Thread::new();
-        copy.thread_index = self.thread_index;
-
-        for e in self.callstack.iter() {
-            copy.callstack.push(e.copy());
-        }
-
-        copy.previous_pointer = self.previous_pointer.clone();
-
-        copy
-    }
-
     pub(crate) fn write_json(&self) -> Result<serde_json::Value, StoryError> {
         let mut thread: Map<String, serde_json::Value> = Map::new();
 
@@ -208,6 +184,7 @@ impl Thread {
     }
 }
 
+#[derive(Clone)]
 pub struct CallStack {
     thread_counter: usize,
     start_of_root: Pointer,
@@ -228,17 +205,7 @@ impl CallStack {
     }
 
     pub fn new_from(to_copy: &CallStack) -> CallStack {
-        let mut cs = CallStack {
-            thread_counter: to_copy.thread_counter,
-            start_of_root: to_copy.start_of_root.clone(),
-            threads: Vec::new(),
-        };
-
-        for other_thread in &to_copy.threads {
-            cs.threads.push(other_thread.copy());
-        }
-
-        cs
+        to_copy.clone()
     }
 
     pub fn get_current_element(&self) -> &Element {
@@ -281,7 +248,7 @@ impl CallStack {
     }
 
     pub fn push_thread(&mut self) {
-        let mut new_thread = self.get_current_thread().copy();
+        let mut new_thread = self.get_current_thread().clone();
         self.thread_counter += 1;
         new_thread.thread_index = self.thread_counter;
         self.threads.push(new_thread);
@@ -348,7 +315,7 @@ impl CallStack {
     }
 
     pub fn fork_thread(&mut self) -> Thread {
-        let mut forked_thread = self.get_current_thread().copy();
+        let mut forked_thread = self.get_current_thread().clone();
         self.thread_counter += 1;
         forked_thread.thread_index = self.thread_counter;
         forked_thread

--- a/lib/src/choice.rs
+++ b/lib/src/choice.rs
@@ -76,7 +76,7 @@ impl Choice {
         self.thread_at_generation
             .borrow()
             .as_ref()
-            .map(|t| t.copy())
+            .map(|t| t.clone())
     }
 }
 

--- a/lib/src/flow.rs
+++ b/lib/src/flow.rs
@@ -137,7 +137,7 @@ impl Flow {
             self.callstack
                 .borrow()
                 .get_thread_with_index(*choice.original_thread_index.borrow())
-                .map(|o| choice.set_thread_at_generation(o.copy()))
+                .map(|o| choice.set_thread_at_generation(o.clone()))
                 .or_else(|| {
                     let j_saved_choice_thread = j_choice_threads
                         .and_then(|c| c.get(choice.original_thread_index.borrow().to_string()))

--- a/lib/src/state_patch.rs
+++ b/lib/src/state_patch.rs
@@ -14,20 +14,12 @@ pub struct StatePatch {
 }
 
 impl StatePatch {
-    pub fn new(to_copy: Option<&StatePatch>) -> StatePatch {
-        match to_copy {
-            Some(to_copy) => StatePatch {
-                globals: to_copy.globals.clone(),
-                changed_variables: to_copy.changed_variables.clone(),
-                visit_counts: to_copy.visit_counts.clone(),
-                turn_indices: to_copy.turn_indices.clone(),
-            },
-            None => StatePatch {
-                globals: HashMap::new(),
-                changed_variables: HashSet::new(),
-                visit_counts: HashMap::new(),
-                turn_indices: HashMap::new(),
-            },
+    pub fn new() -> StatePatch {
+        StatePatch {
+            globals: HashMap::new(),
+            changed_variables: HashSet::new(),
+            visit_counts: HashMap::new(),
+            turn_indices: HashMap::new(),
         }
     }
 

--- a/lib/src/story.rs
+++ b/lib/src/story.rs
@@ -752,7 +752,7 @@ impl Story {
             .get_callstack()
             .as_ref()
             .borrow_mut()
-            .set_current_thread(choice.get_thread_at_generation().unwrap().copy());
+            .set_current_thread(choice.get_thread_at_generation().unwrap().clone());
 
         // If there's a chance that this state will be rolled back to before
         // the invisible choice then make sure that the choice thread is

--- a/lib/src/story_state.rs
+++ b/lib/src/story_state.rs
@@ -758,7 +758,7 @@ impl StoryState {
             self.list_definitions.clone(),
         );
 
-        copy.patch = Some(StatePatch::new(self.patch.as_ref()));
+        copy.patch = Some(self.patch.clone().unwrap_or_else(StatePatch::new));
 
         // Hijack the new default flow to become a copy of our current one
         // If the patch is applied, then this new flow will replace the old one in

--- a/lib/src/story_state.rs
+++ b/lib/src/story_state.rs
@@ -764,9 +764,9 @@ impl StoryState {
         // If the patch is applied, then this new flow will replace the old one in
         // _namedFlows
         copy.current_flow.name = self.current_flow.name.clone();
-        copy.current_flow.callstack = Rc::new(RefCell::new(CallStack::new_from(
-            &self.current_flow.callstack.as_ref().borrow(),
-        )));
+        copy.current_flow.callstack = Rc::new(RefCell::new(
+            self.current_flow.callstack.as_ref().borrow().clone(),
+        ));
         copy.current_flow.current_choices = self.current_flow.current_choices.clone();
         copy.current_flow.output_stream = self.current_flow.output_stream.clone();
         copy.output_stream_dirty();


### PR DESCRIPTION
As best I could tell, all the hand-rolled `copy` functions were just doing a clone, so it'll be simpler, more legible and less work to maintain if they're just using the inbuilt derived `clone` implementation.