### PR TITLE
Match CLI player output to Inklecate formatting

### DIFF
--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -1,12 +1,15 @@
-//! Console player that can runs compiled `.ink.json` story files writen in the **Ink** language.
+//! Console player that can runs compiled `.ink.json` story files writen in the
+//! **Ink** language.
 use std::cell::RefCell;
 
-use std::io::Write;
-use std::{error::Error, fs, io, path::Path, rc::Rc};
+use std::{error::Error, fs, io, io::Write, path::Path, rc::Rc};
 
 use anyhow::Context;
-use bladeink::story_callbacks::{ErrorHandler, ErrorType};
-use bladeink::{choice::Choice, story::Story};
+use bladeink::{
+    choice::Choice,
+    story::Story,
+    story_callbacks::{ErrorHandler, ErrorType},
+};
 use clap::Parser;
 use rand::Rng;
 
@@ -44,7 +47,7 @@ impl EHandler {
 
 impl ErrorHandler for EHandler {
     fn error(&mut self, message: &str, error_type: ErrorType) {
-        println!("{}", message);
+        eprintln!("{}", message);
 
         if error_type == ErrorType::Error {
             self.should_terminate = true;
@@ -71,7 +74,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let trimmed = line.trim();
 
-            println!("{}", trimmed);
+            if !trimmed.is_empty() {
+                println!("{}", trimmed);
+            }
         }
 
         let choices = story.get_current_choices();
@@ -81,8 +86,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 println!();
                 print_choices(&choices);
-                println!();
-                println!("?>{i}");
+                println!("?> {i}");
 
                 Command::Choose(i)
             } else {
@@ -130,7 +134,7 @@ fn process_command(command: Command, story: &mut Story) -> Result<bool, Box<dyn 
 
 fn print_choices(choices: &[Rc<Choice>]) {
     for (i, c) in choices.iter().enumerate() {
-        println!("{}. {}", i + 1, c.text);
+        println!("{}: {}", i + 1, c.text);
     }
 }
 
@@ -140,8 +144,7 @@ fn read_input(choices: &Vec<Rc<Choice>>) -> Result<Command, Box<dyn Error>> {
     loop {
         println!();
         print_choices(choices);
-        println!();
-        print!("?>");
+        print!("?> ");
         io::stdout().flush()?;
 
         line.clear();
@@ -203,7 +206,7 @@ fn read_input(choices: &Vec<Rc<Choice>>) -> Result<Command, Box<dyn Error>> {
 }
 
 fn print_error(error: &str) {
-    println!("<{error}>");
+    eprintln!("<{error}>");
 }
 
 fn get_json_string(filename: &str) -> Result<String, Box<dyn Error>> {

--- a/cli-player/tests/basic_tests.rs
+++ b/cli-player/tests/basic_tests.rs
@@ -1,8 +1,10 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::predicate; // Add methods on commands
-use std::io::Write;
-use std::path::Path;
-use std::process::{Command, Stdio};
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 #[test]
 fn basic_story_test() -> Result<(), Box<dyn std::error::Error>> {
@@ -10,7 +12,8 @@ fn basic_story_test() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut path = Path::new("inkfiles/test1.ink.json").to_path_buf();
 
-    // Due to a bug with Cargo workspaces, for Release mode the current folder is the crate folder and for Debug mode the current folder is the root folder.
+    // Due to a bug with Cargo workspaces, for Release mode the current folder is
+    // the crate folder and for Debug mode the current folder is the root folder.
     if !path.exists() {
         path = Path::new("../").join(path);
     }
@@ -29,7 +32,7 @@ fn basic_story_test() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(output.status.success());
     assert!(output_str.contains("Test conditional choices"));
-    assert!(output_str.contains("1. one"));
+    assert!(output_str.contains("1: one"));
     assert!(output_str.ends_with("one\n"));
 
     Ok(())

--- a/cli-player/tests/test_the_intercept.rs
+++ b/cli-player/tests/test_the_intercept.rs
@@ -1,7 +1,9 @@
 use assert_cmd::prelude::*;
-use std::io::Write;
-use std::path::Path;
-use std::process::{Command, Stdio};
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 #[test]
 fn the_intercept_test() -> Result<(), Box<dyn std::error::Error>> {
@@ -9,7 +11,8 @@ fn the_intercept_test() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut path = Path::new("inkfiles/TheIntercept.ink.json").to_path_buf();
 
-    // Due to a bug with Cargo workspaces, for Release mode the current folder is the crate folder and for Debug mode the current folder is the root folder.
+    // Due to a bug with Cargo workspaces, for Release mode the current folder is
+    // the crate folder and for Debug mode the current folder is the root folder.
     if !path.exists() {
         path = Path::new("../").join(path);
     }
@@ -28,9 +31,9 @@ fn the_intercept_test() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(output.status.success());
     assert!(output_str.starts_with("They are keeping me waiting."));
-    assert!(output_str.contains("1. Hut 14"));
-    assert!(output_str.contains("3. Wait"));
-    assert!(output_str.contains("3. Divert"));
+    assert!(output_str.contains("1: Hut 14"));
+    assert!(output_str.contains("3: Wait"));
+    assert!(output_str.contains("3: Divert"));
 
     Ok(())
 }


### PR DESCRIPTION
Change formatting for command-line program's output to match `inklecate` (so that ink-proof test suite mostly passes).