### PR TITLE
Use crate instant to allow the lib works in wasm

### DIFF
--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let json_string = get_json_string(&args.json_filename)?;
 
-    // REMOVE BOM if exits
+    // REMOVE BOM if exists
     let json_string_without_bom = json_string.strip_prefix('\u{feff}').unwrap_or(&json_string);
 
     let mut story = Story::new(json_string_without_bom)?;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,3 +22,8 @@ serde_json = "1.0.93"
 strum = { version = "0.25.0", features = ["derive"] }
 as-any = "0.3.0"
 rand = "0.8.5"
+instant = "0.1.12"
+
+[features]
+stdweb = [ "instant/stdweb" ]
+wasm-bindgen = [ "instant/wasm-bindgen" ]

--- a/lib/src/story/progress.rs
+++ b/lib/src/story/progress.rs
@@ -11,7 +11,7 @@ use crate::{
     value::Value,
     void::Void,
 };
-use std::{self, rc::Rc, time::Instant};
+use std::{self, rc::Rc};
 
 /// # Story Progress
 /// Methods to move the story forwards.
@@ -93,8 +93,11 @@ impl Story {
             }
         }
 
-        // Start timing
-        let duration_stopwatch = Instant::now();
+        // Start timing (only when necessary)
+        let duration_stopwatch = match self.async_continue_active {
+            true => Some(instant::Instant::now()),
+            false => None,
+        };
 
         let mut output_stream_ends_in_newline = false;
         self.saw_lookahead_unsafe_function_after_new_line = false;
@@ -114,7 +117,8 @@ impl Story {
 
             // Run out of async time?
             if self.async_continue_active
-                && duration_stopwatch.elapsed().as_millis() as f32 > millisecs_limit_async
+                && duration_stopwatch.as_ref().unwrap().elapsed().as_millis() as f32
+                    > millisecs_limit_async
             {
                 break;
             }


### PR DESCRIPTION
Fix for https://github.com/bladecoder/blade-ink-rs/issues/11.

We will use the crate https://github.com/sebcrozet/instant that emulates the struct `Instant` in WASM and uses the `Instant` std if native.

Also we avoid to call `instant::now()` if it is not necessary.