### PR TITLE
 Turn off Binkplayer error on external function fallbacks

### DIFF
--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -25,7 +25,7 @@ struct Args {
     #[arg(short, default_value_t = false)]
     pub auto_play: bool,
 
-    /// Allow external function fallbacks
+    /// Forbid external function fallbacks
     #[arg(short = 'e', default_value_t = false)]
     pub forbid_external_fallbacks: bool,
 }

--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -24,6 +24,10 @@ struct Args {
     /// Choose options randomly
     #[arg(short, default_value_t = false)]
     pub auto_play: bool,
+
+    /// Allow external function fallbacks
+    #[arg(short, default_value_t = false)]
+    pub external_fallbacks: bool,
 }
 
 enum Command {
@@ -68,6 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut story = Story::new(json_string_without_bom)?;
     let err_handler = EHandler::new();
     story.set_error_handler(err_handler.clone());
+    story.set_allow_external_function_fallbacks(args.external_fallbacks);
 
     let mut end = false;
 

--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 println!();
                 print_choices(&choices);
-                println!("?> {i}");
+                println!("?> {}", i + 1);
 
                 Command::Choose(i)
             } else {

--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -26,7 +26,7 @@ struct Args {
     pub auto_play: bool,
 
     /// Allow external function fallbacks
-    #[arg(short='e', default_value_t = false)]
+    #[arg(short = 'e', default_value_t = false)]
     pub forbid_external_fallbacks: bool,
 }
 

--- a/cli-player/src/main.rs
+++ b/cli-player/src/main.rs
@@ -26,8 +26,8 @@ struct Args {
     pub auto_play: bool,
 
     /// Allow external function fallbacks
-    #[arg(short, default_value_t = false)]
-    pub external_fallbacks: bool,
+    #[arg(short='e', default_value_t = false)]
+    pub forbid_external_fallbacks: bool,
 }
 
 enum Command {
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut story = Story::new(json_string_without_bom)?;
     let err_handler = EHandler::new();
     story.set_error_handler(err_handler.clone());
-    story.set_allow_external_function_fallbacks(args.external_fallbacks);
+    story.set_allow_external_function_fallbacks(!args.forbid_external_fallbacks);
 
     let mut end = false;
 


### PR DESCRIPTION
This was meant to be #16 but I have no idea what's going on with the commits in that PR due to force pushes, so this PR is a replacement for it.

---

Currently, Binkplayer throws an error if the provided .ink.json contains a fallback for an external function. With this PR, it does not throw that error unless the -e CLI flag is passed.

The CLI doesn't let you properly handle external functions, so without this change, it's not possible to run Ink with external functions at all, even if they have fallbacks.

I'm also sneaking in a fix for an off-by-one error in the display of randomly chosen choices — happy to cherry-pick into a different PR. My reason for including it is that both changes came from attempting to use that auto_play mode to test an existing Ink story, and finding both issues.
