### PR TITLE
Refactor Value/ValueType methods into built-in traits

### DIFF
--- a/lib/src/json/json_read.rs
+++ b/lib/src/json/json_read.rs
@@ -94,14 +94,14 @@ pub fn jtoken_to_runtime_object(
             "Failed to convert token to runtime RTObject: {}",
             token
         ))),
-        serde_json::Value::Bool(value) => Ok(Rc::new(Value::new_bool(value.to_owned()))),
+        serde_json::Value::Bool(value) => Ok(Rc::new(Value::new::<bool>(value.to_owned()))),
         serde_json::Value::Number(_) => {
             if token.is_i64() {
                 let val: i32 = token.as_i64().unwrap().try_into().unwrap();
-                Ok(Rc::new(Value::new_int(val)))
+                Ok(Rc::new(Value::new::<i32>(val)))
             } else {
                 let val: f32 = token.as_f64().unwrap() as f32;
-                Ok(Rc::new(Value::new_float(val)))
+                Ok(Rc::new(Value::new::<f32>(val)))
             }
         }
 
@@ -111,9 +111,9 @@ pub fn jtoken_to_runtime_object(
             // String value
             let first_char = str.chars().next().unwrap();
             if first_char == '^' {
-                return Ok(Rc::new(Value::new_string(&str[1..])));
+                return Ok(Rc::new(Value::new::<&str>(&str[1..])));
             } else if first_char == '\n' && str.len() == 1 {
-                return Ok(Rc::new(Value::new_string("\n")));
+                return Ok(Rc::new(Value::new::<&str>("\n")));
             }
 
             // Glue
@@ -153,7 +153,7 @@ pub fn jtoken_to_runtime_object(
             let prop_value = obj.get("^->");
 
             if let Some(prop_value) = prop_value {
-                return Ok(Rc::new(Value::new_divert_target(
+                return Ok(Rc::new(Value::new::<Path>(
                     Path::new_with_components_string(prop_value.as_str()),
                 )));
             }
@@ -336,7 +336,7 @@ pub fn jtoken_to_runtime_object(
                     raw_list.items.insert(item, v.as_i64().unwrap() as i32);
                 }
 
-                return Ok(Rc::new(Value::new_list(raw_list)));
+                return Ok(Rc::new(Value::new::<InkList>(raw_list)));
             }
 
             // Used when serialising save state only

--- a/lib/src/json/json_read_stream.rs
+++ b/lib/src/json/json_read_stream.rs
@@ -123,14 +123,14 @@ fn jtoken_to_runtime_object(
 ) -> Result<ArrayElement, StoryError> {
     match value {
         JsonValue::Null => Ok(ArrayElement::NullElement),
-        JsonValue::Boolean(value) => Ok(ArrayElement::RTObject(Rc::new(Value::new_bool(value)))),
+        JsonValue::Boolean(value) => Ok(ArrayElement::RTObject(Rc::new(Value::new::<bool>(value)))),
         JsonValue::Number(value) => {
             if value.is_integer() {
                 let val: i32 = value.as_integer().unwrap();
-                Ok(ArrayElement::RTObject(Rc::new(Value::new_int(val))))
+                Ok(ArrayElement::RTObject(Rc::new(Value::new::<i32>(val))))
             } else {
                 let val: f32 = value.as_float().unwrap();
-                Ok(ArrayElement::RTObject(Rc::new(Value::new_float(val))))
+                Ok(ArrayElement::RTObject(Rc::new(Value::new::<f32>(val))))
             }
         }
         JsonValue::String(value) => {
@@ -139,11 +139,11 @@ fn jtoken_to_runtime_object(
             // String value
             let first_char = str.chars().next().unwrap();
             if first_char == '^' {
-                return Ok(ArrayElement::RTObject(Rc::new(Value::new_string(
+                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<&str>(
                     &str[1..],
                 ))));
             } else if first_char == '\n' && str.len() == 1 {
-                return Ok(ArrayElement::RTObject(Rc::new(Value::new_string("\n"))));
+                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<&str>("\n"))));
             }
 
             // Glue
@@ -185,7 +185,7 @@ fn jtoken_to_runtime_object(
             // Divert target value to path
             if prop == "^->" {
                 tok.expect('}')?;
-                return Ok(ArrayElement::RTObject(Rc::new(Value::new_divert_target(
+                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<Path>(
                     Path::new_with_components_string(prop_value.as_str()),
                 ))));
             }
@@ -375,7 +375,7 @@ fn jtoken_to_runtime_object(
                 }
 
                 tok.expect('}')?;
-                return Ok(ArrayElement::RTObject(Rc::new(Value::new_list(raw_list))));
+                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<InkList>(raw_list))));
             }
 
             // Used when serialising save state only

--- a/lib/src/json/json_read_stream.rs
+++ b/lib/src/json/json_read_stream.rs
@@ -375,7 +375,9 @@ fn jtoken_to_runtime_object(
                 }
 
                 tok.expect('}')?;
-                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<InkList>(raw_list))));
+                return Ok(ArrayElement::RTObject(Rc::new(Value::new::<InkList>(
+                    raw_list,
+                ))));
             }
 
             // Used when serialising save state only

--- a/lib/src/json/json_write.rs
+++ b/lib/src/json/json_write.rs
@@ -3,11 +3,24 @@ use std::{collections::HashMap, rc::Rc};
 use serde_json::{json, Map};
 
 use crate::{
-    choice::Choice, choice_point::ChoicePoint, container::Container,
-    control_command::ControlCommand, divert::Divert, glue::Glue, ink_list::InkList,
-    native_function_call::NativeFunctionCall, object::RTObject, push_pop::PushPopType,
-    story_error::StoryError, tag::Tag, value::Value, variable_assigment::VariableAssignment,
-    variable_reference::VariableReference, void::Void,
+    choice::Choice,
+    choice_point::ChoicePoint,
+    container::Container,
+    control_command::ControlCommand,
+    divert::Divert,
+    glue::Glue,
+    ink_list::InkList,
+    native_function_call::NativeFunctionCall,
+    object::RTObject,
+    path::Path,
+    push_pop::PushPopType,
+    story_error::StoryError,
+    tag::Tag,
+    value::Value,
+    value_type::{StringValue, VariablePointerValue},
+    variable_assigment::VariableAssignment,
+    variable_reference::VariableReference,
+    void::Void,
 };
 
 pub fn write_dictionary_values(
@@ -79,15 +92,15 @@ pub fn write_rtobject(o: Rc<dyn RTObject>) -> Result<serde_json::Value, StoryErr
         return Ok(json!(v));
     }
 
-    if let Some(v) = Value::get_int_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<i32>(o.as_ref()) {
         return Ok(json!(v));
     }
 
-    if let Some(v) = Value::get_float_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<f32>(o.as_ref()) {
         return Ok(json!(v));
     }
 
-    if let Some(v) = Value::get_string_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<&StringValue>(o.as_ref()) {
         let mut s = String::new();
 
         if v.is_newline {
@@ -100,17 +113,17 @@ pub fn write_rtobject(o: Rc<dyn RTObject>) -> Result<serde_json::Value, StoryErr
         return Ok(json!(s));
     }
 
-    if let Some(v) = Value::get_list_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<&InkList>(o.as_ref()) {
         return Ok(write_ink_list(v));
     }
 
-    if let Some(v) = Value::get_divert_target_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<&Path>(o.as_ref()) {
         let mut jobj: Map<String, serde_json::Value> = Map::new();
         jobj.insert("^->".to_owned(), json!(v.get_components_string()));
         return Ok(serde_json::Value::Object(jobj));
     }
 
-    if let Some(v) = Value::get_variable_pointer_value(o.as_ref()) {
+    if let Some(v) = Value::get_value::<&VariablePointerValue>(o.as_ref()) {
         let mut jobj: Map<String, serde_json::Value> = Map::new();
         jobj.insert("^var".to_owned(), json!(v.variable_name));
         jobj.insert("ci".to_owned(), json!(v.context_index));

--- a/lib/src/list_definitions_origin.rs
+++ b/lib/src/list_definitions_origin.rs
@@ -24,7 +24,7 @@ impl ListDefinitionsOrigin {
                 let mut l = InkList::new();
                 l.items.insert(key.clone(), *val);
 
-                let list_value = Rc::new(Value::new_list(l));
+                let list_value = Rc::new(Value::new::<InkList>(l));
 
                 list_definitions_origin
                     .all_unambiguous_list_value_cache

--- a/lib/src/native_function_call.rs
+++ b/lib/src/native_function_call.rs
@@ -265,7 +265,7 @@ impl NativeFunctionCall {
                 }
             };
 
-            return Ok(Rc::new(Value::new_bool(result)));
+            return Ok(Rc::new(Value::new::<bool>(result)));
         }
 
         // Normal (list • list) operation
@@ -315,7 +315,7 @@ impl NativeFunctionCall {
             }
         }
 
-        Rc::new(Value::new_list(result_raw_list))
+        Rc::new(Value::new::<InkList>(result_raw_list))
     }
 
     fn call_type(&self, coerced_params: Vec<Rc<Value>>) -> Result<Rc<dyn RTObject>, StoryError> {
@@ -397,25 +397,25 @@ impl NativeFunctionCall {
     fn and_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Bool(op1) => match params[1].value {
-                ValueType::Bool(op2) => Ok(Rc::new(Value::new_bool(*op1 && op2))),
+                ValueType::Bool(op2) => Ok(Rc::new(Value::new::<bool>(*op1 && op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 != 0 && op2 != 0))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != 0 && op2 != 0))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 != 0.0 && op2 != 0.0))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != 0.0 && op2 != 0.0))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(
                     !op1.items.is_empty() && !op2.items.is_empty(),
                 ))),
                 _ => Err(StoryError::InvalidStoryState(
@@ -431,19 +431,19 @@ impl NativeFunctionCall {
     fn greater_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 > op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 > op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 > op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 > op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(op1.greater_than(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(op1.greater_than(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -457,19 +457,19 @@ impl NativeFunctionCall {
     fn less_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 < op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 < op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 < op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 < op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(op1.less_than(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(op1.less_than(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -486,20 +486,20 @@ impl NativeFunctionCall {
     ) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 >= op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 >= op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 >= op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 >= op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
                 ValueType::List(op2) => {
-                    Ok(Rc::new(Value::new_bool(op1.greater_than_or_equals(op2))))
+                    Ok(Rc::new(Value::new::<bool>(op1.greater_than_or_equals(op2))))
                 }
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
@@ -514,19 +514,19 @@ impl NativeFunctionCall {
     fn less_than_or_equals_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 <= op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 <= op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 <= op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 <= op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(op1.less_than_or_equals(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(op1.less_than_or_equals(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -540,19 +540,19 @@ impl NativeFunctionCall {
     fn subtract_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(*op1 - op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(*op1 - op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(*op1 - op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(*op1 - op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_list(op1.without(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<InkList>(op1.without(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -566,13 +566,13 @@ impl NativeFunctionCall {
     fn add_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(op1 + op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(op1 + op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(op1 + op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(op1 + op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -582,14 +582,14 @@ impl NativeFunctionCall {
                     let mut sb = String::new();
                     sb.push_str(&op1.string);
                     sb.push_str(&op2.string);
-                    Ok(Rc::new(Value::new_string(&sb)))
+                    Ok(Rc::new(Value::new::<&str>(&sb)))
                 }
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_list(op1.union(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<InkList>(op1.union(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -603,13 +603,13 @@ impl NativeFunctionCall {
     fn divide_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(op1 / op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(op1 / op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(op1 / op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(op1 / op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -623,13 +623,13 @@ impl NativeFunctionCall {
     fn pow_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_float((op1 as f32).powf(op2 as f32)))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<f32>((op1 as f32).powf(op2 as f32)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(op1.powf(op2)))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(op1.powf(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -643,13 +643,13 @@ impl NativeFunctionCall {
     fn multiply_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(op1 * op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(op1 * op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(op1 * op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(op1 * op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -663,25 +663,25 @@ impl NativeFunctionCall {
     fn or_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Bool(op1) => match params[1].value {
-                ValueType::Bool(op2) => Ok(Rc::new(Value::new_bool(*op1 || op2))),
+                ValueType::Bool(op2) => Ok(Rc::new(Value::new::<bool>(*op1 || op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 != 0 || op2 != 0))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != 0 || op2 != 0))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 != 0.0 || op2 != 0.0))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != 0.0 || op2 != 0.0))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(
                     !op1.items.is_empty() || !op2.items.is_empty(),
                 ))),
                 _ => Err(StoryError::InvalidStoryState(
@@ -696,9 +696,9 @@ impl NativeFunctionCall {
 
     fn not_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_bool(*op1 == 0))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_bool(*op1 == 0.0))),
-            ValueType::List(op1) => Ok(Rc::new(Value::new_int(match op1.items.is_empty() {
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<bool>(*op1 == 0))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<bool>(*op1 == 0.0))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<i32>(match op1.items.is_empty() {
                 true => 1,
                 false => 0,
             }))),
@@ -711,13 +711,13 @@ impl NativeFunctionCall {
     fn min_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(i32::min(*op1, op2)))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(i32::min(*op1, op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(f32::min(*op1, op2)))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(f32::min(*op1, op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -731,13 +731,13 @@ impl NativeFunctionCall {
     fn max_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(i32::max(*op1, op2)))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(i32::max(*op1, op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(f32::max(*op1, op2)))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(f32::max(*op1, op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -751,37 +751,37 @@ impl NativeFunctionCall {
     fn equal_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Bool(op1) => match params[1].value {
-                ValueType::Bool(op2) => Ok(Rc::new(Value::new_bool(*op1 == op2))),
+                ValueType::Bool(op2) => Ok(Rc::new(Value::new::<bool>(*op1 == op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 == op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 == op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 == op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 == op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::String(op1) => match &params[1].value {
-                ValueType::String(op2) => Ok(Rc::new(Value::new_bool(op1.string.eq(&op2.string)))),
+                ValueType::String(op2) => Ok(Rc::new(Value::new::<bool>(op1.string.eq(&op2.string)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(op1.eq(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(op1.eq(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::DivertTarget(op1) => match &params[1].value {
-                ValueType::DivertTarget(op2) => Ok(Rc::new(Value::new_bool(op1.eq(op2)))),
+                ValueType::DivertTarget(op2) => Ok(Rc::new(Value::new::<bool>(op1.eq(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -795,37 +795,37 @@ impl NativeFunctionCall {
     fn not_equals_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::Bool(op1) => match params[1].value {
-                ValueType::Bool(op2) => Ok(Rc::new(Value::new_bool(*op1 != op2))),
+                ValueType::Bool(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_bool(*op1 != op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_bool(*op1 != op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<bool>(*op1 != op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::String(op1) => match &params[1].value {
-                ValueType::String(op2) => Ok(Rc::new(Value::new_bool(!op1.string.eq(&op2.string)))),
+                ValueType::String(op2) => Ok(Rc::new(Value::new::<bool>(!op1.string.eq(&op2.string)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(!op1.eq(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(!op1.eq(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::DivertTarget(op1) => match &params[1].value {
-                ValueType::DivertTarget(op2) => Ok(Rc::new(Value::new_bool(!op1.eq(op2)))),
+                ValueType::DivertTarget(op2) => Ok(Rc::new(Value::new::<bool>(!op1.eq(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -839,13 +839,13 @@ impl NativeFunctionCall {
     fn mod_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match params[0].value {
             ValueType::Int(op1) => match params[1].value {
-                ValueType::Int(op2) => Ok(Rc::new(Value::new_int(op1 % op2))),
+                ValueType::Int(op2) => Ok(Rc::new(Value::new::<i32>(op1 % op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::Float(op1) => match params[1].value {
-                ValueType::Float(op2) => Ok(Rc::new(Value::new_float(op1 % op2))),
+                ValueType::Float(op2) => Ok(Rc::new(Value::new::<f32>(op1 % op2))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -859,7 +859,7 @@ impl NativeFunctionCall {
     fn intersect_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_list(op1.intersect(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<InkList>(op1.intersect(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -874,14 +874,14 @@ impl NativeFunctionCall {
         match &params[0].value {
             ValueType::String(op1) => match &params[1].value {
                 ValueType::String(op2) => {
-                    Ok(Rc::new(Value::new_bool(op1.string.contains(&op2.string))))
+                    Ok(Rc::new(Value::new::<bool>(op1.string.contains(&op2.string))))
                 }
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(op1.contains(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(op1.contains(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -896,14 +896,14 @@ impl NativeFunctionCall {
         match &params[0].value {
             ValueType::String(op1) => match &params[1].value {
                 ValueType::String(op2) => {
-                    Ok(Rc::new(Value::new_bool(!op1.string.contains(&op2.string))))
+                    Ok(Rc::new(Value::new::<bool>(!op1.string.contains(&op2.string))))
                 }
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
             },
             ValueType::List(op1) => match &params[1].value {
-                ValueType::List(op2) => Ok(Rc::new(Value::new_bool(!op1.contains(op2)))),
+                ValueType::List(op2) => Ok(Rc::new(Value::new::<bool>(!op1.contains(op2)))),
                 _ => Err(StoryError::InvalidStoryState(
                     "Operation not available for type.".to_owned(),
                 )),
@@ -917,8 +917,8 @@ impl NativeFunctionCall {
     fn value_of_list_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
             ValueType::List(op1) => match op1.get_max_item() {
-                Some(i) => Ok(Rc::new(Value::new_int(i.1))),
-                None => Ok(Rc::new(Value::new_int(0))),
+                Some(i) => Ok(Rc::new(Value::new::<i32>(i.1))),
+                None => Ok(Rc::new(Value::new::<i32>(0))),
             },
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
@@ -928,7 +928,7 @@ impl NativeFunctionCall {
 
     fn all_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::List(op1) => Ok(Rc::new(Value::new_list(op1.get_all()))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<InkList>(op1.get_all()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -937,7 +937,7 @@ impl NativeFunctionCall {
 
     fn inverse_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::List(op1) => Ok(Rc::new(Value::new_list(op1.inverse()))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<InkList>(op1.inverse()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -946,7 +946,7 @@ impl NativeFunctionCall {
 
     fn count_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::List(op1) => Ok(Rc::new(Value::new_int(op1.items.len() as i32))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<i32>(op1.items.len() as i32))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -955,7 +955,7 @@ impl NativeFunctionCall {
 
     fn list_max_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::List(op1) => Ok(Rc::new(Value::new_list(op1.max_as_list()))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<InkList>(op1.max_as_list()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -964,7 +964,7 @@ impl NativeFunctionCall {
 
     fn list_min_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::List(op1) => Ok(Rc::new(Value::new_list(op1.min_as_list()))),
+            ValueType::List(op1) => Ok(Rc::new(Value::new::<InkList>(op1.min_as_list()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -973,8 +973,8 @@ impl NativeFunctionCall {
 
     fn negate_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_int(-op1))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_float(-op1))),
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<i32>(-op1))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<f32>(-op1))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -983,8 +983,8 @@ impl NativeFunctionCall {
 
     fn floor_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_int(*op1))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_float(op1.floor()))),
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<i32>(*op1))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<f32>(op1.floor()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -993,8 +993,8 @@ impl NativeFunctionCall {
 
     fn ceiling_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_int(*op1))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_float(op1.ceil()))),
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<i32>(*op1))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<f32>(op1.ceil()))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -1003,8 +1003,8 @@ impl NativeFunctionCall {
 
     fn int_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_int(*op1))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_int(*op1 as i32))),
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<i32>(*op1))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<i32>(*op1 as i32))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),
@@ -1013,8 +1013,8 @@ impl NativeFunctionCall {
 
     fn float_op(&self, params: &[Rc<Value>]) -> Result<Rc<dyn RTObject>, StoryError> {
         match &params[0].value {
-            ValueType::Int(op1) => Ok(Rc::new(Value::new_float(*op1 as f32))),
-            ValueType::Float(op1) => Ok(Rc::new(Value::new_float(*op1))),
+            ValueType::Int(op1) => Ok(Rc::new(Value::new::<f32>(*op1 as f32))),
+            ValueType::Float(op1) => Ok(Rc::new(Value::new::<f32>(*op1))),
             _ => Err(StoryError::InvalidStoryState(
                 "Operation not available for type.".to_owned(),
             )),

--- a/lib/src/story/choices.rs
+++ b/lib/src/story/choices.rs
@@ -1,6 +1,6 @@
 use crate::{
     choice::Choice, choice_point::ChoicePoint, object::Object, path::Path, story::Story,
-    story_error::StoryError, tag::Tag, value::Value,
+    story_error::StoryError, tag::Tag, value::Value, value_type::StringValue,
 };
 use std::rc::Rc;
 /// # Choices
@@ -156,7 +156,7 @@ impl Story {
 
     fn pop_choice_string_and_tags(&mut self, tags: &mut Vec<String>) -> String {
         let obj = self.get_state_mut().pop_evaluation_stack();
-        let choice_only_str_val = Value::get_string_value(obj.as_ref()).unwrap();
+        let choice_only_str_val = Value::get_value::<&StringValue>(obj.as_ref()).unwrap();
 
         while !self.get_state().evaluation_stack.is_empty()
             && self

--- a/lib/src/story/control_logic.rs
+++ b/lib/src/story/control_logic.rs
@@ -129,7 +129,7 @@ impl Story {
                             // only problem is when exporting text for viewing, it
                             // skips over numbers etc.
                             let text: Rc<dyn RTObject> =
-                                Rc::new(Value::new_string(&output.to_string()));
+                                Rc::new(Value::new::<&str>(&output.to_string()));
                             self.get_state_mut().push_to_output_stream(text);
                         }
                     }
@@ -284,18 +284,18 @@ impl Story {
                     // Return to expression evaluation (from content mode)
                     self.get_state().set_in_expression_evaluation(true);
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_string(&sb)));
+                        .push_evaluation_stack(Rc::new(Value::new::<&str>(&sb)));
                 }
                 CommandType::NoOp => {}
                 CommandType::ChoiceCount => {
                     let choice_count = self.get_state().get_generated_choices().len();
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_int(choice_count as i32)));
+                        .push_evaluation_stack(Rc::new(Value::new::<i32>(choice_count as i32)));
                 }
                 CommandType::Turns => {
                     let current_turn = self.get_state().current_turn_index;
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_int(current_turn + 1)));
+                        .push_evaluation_stack(Rc::new(Value::new::<i32>(current_turn + 1)));
                 }
                 CommandType::TurnsSince | CommandType::ReadCount => {
                     let target = self.get_state_mut().pop_evaluation_stack();
@@ -347,7 +347,7 @@ impl Story {
                     }
 
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_int(either_count)));
+                        .push_evaluation_stack(Rc::new(Value::new::<i32>(either_count)));
                 }
                 CommandType::Random => {
                     let mut max_int = None;
@@ -392,7 +392,7 @@ impl Story {
                     let next_random = rng.gen::<u32>();
                     let chosen_value = (next_random % random_range as u32) as i32 + min_value;
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_int(chosen_value)));
+                        .push_evaluation_stack(Rc::new(Value::new::<i32>(chosen_value)));
                     self.get_state_mut().previous_random = self.get_state().previous_random + 1;
                 }
                 CommandType::SeedRandom => {
@@ -419,11 +419,11 @@ impl Story {
                     let count = self.get_state_mut().visit_count_for_container(&cpc) - 1; // index
                                                                                           // not count
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_int(count)));
+                        .push_evaluation_stack(Rc::new(Value::new::<i32>(count)));
                 }
                 CommandType::SequenceShuffleIndex => {
                     let shuffle_index = self.next_sequence_shuffle_index()?;
-                    let v = Rc::new(Value::new_int(shuffle_index));
+                    let v = Rc::new(Value::new::<i32>(shuffle_index));
                     self.get_state_mut().push_evaluation_stack(v);
                 }
                 CommandType::StartThread => {
@@ -477,7 +477,7 @@ impl Story {
                                 found_item.clone(),
                                 int_val.unwrap(),
                             ));
-                            generated_list_value = Some(Value::new_list(l));
+                            generated_list_value = Some(Value::new::<InkList>(l));
                         }
                     } else {
                         return Err(StoryError::InvalidStoryState(format!(
@@ -487,7 +487,7 @@ impl Story {
                     }
 
                     if generated_list_value.is_none() {
-                        generated_list_value = Some(Value::new_list(InkList::new()));
+                        generated_list_value = Some(Value::new::<InkList>(InkList::new()));
                     }
 
                     self.get_state_mut()
@@ -510,7 +510,7 @@ impl Story {
                         .unwrap()
                         .list_with_sub_range(&min.unwrap().value, &max.unwrap().value);
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_list(result)));
+                        .push_evaluation_stack(Rc::new(Value::new::<InkList>(result)));
                 }
                 CommandType::ListRandom => {
                     let o = self.get_state_mut().pop_evaluation_stack();
@@ -549,7 +549,7 @@ impl Story {
                         }
                     };
                     self.get_state_mut()
-                        .push_evaluation_stack(Rc::new(Value::new_list(new_list)));
+                        .push_evaluation_stack(Rc::new(Value::new::<InkList>(new_list)));
                 }
                 CommandType::BeginTag => self
                     .get_state_mut()
@@ -658,7 +658,7 @@ impl Story {
                 let count = self
                     .get_state_mut()
                     .visit_count_for_container(container.as_ref().unwrap());
-                found_value = Rc::new(Value::new_int(count));
+                found_value = Rc::new(Value::new::<i32>(count));
             }
             // Normal variable reference
             else {
@@ -670,7 +670,7 @@ impl Story {
                     Some(v) => found_value = v,
                     None => {
                         self.add_error(&format!("Variable not found: '{}'. Using default value of 0 (false). This can happen with temporary variables if the declaration hasn't yet been hit. Globals are always given a default value on load if a value doesn't exist in the save state.", var_ref.name), true);
-                        found_value = Rc::new(Value::new_int(0));
+                        found_value = Rc::new(Value::new::<i32>(0));
                     }
                 }
             }

--- a/lib/src/story/external_functions.rs
+++ b/lib/src/story/external_functions.rs
@@ -185,7 +185,7 @@ impl Story {
 
         // Convert return value (if any) to a type that the ink engine can use
         let return_obj: Rc<dyn RTObject> = match func_result {
-            Some(func_result) => Rc::new(Value::new(func_result)),
+            Some(func_result) => Rc::new(Value::new_value_type(func_result)),
             None => Rc::new(Void::new()),
         };
 

--- a/lib/src/story/mod.rs
+++ b/lib/src/story/mod.rs
@@ -46,6 +46,7 @@ mod misc {
     use crate::{
         json::{json_read, json_read_stream},
         object::{Object, RTObject},
+        path::Path,
         story::{Story, INK_VERSION_CURRENT},
         story_error::StoryError,
         story_state::StoryState,
@@ -111,7 +112,7 @@ mod misc {
             let truthy = false;
 
             if let Some(val) = obj.as_ref().as_any().downcast_ref::<Value>() {
-                if let Some(target_path) = Value::get_divert_target_value(obj.as_ref()) {
+                if let Some(target_path) = Value::get_value::<&Path>(obj.as_ref()) {
                     return Err(StoryError::InvalidStoryState(format!("Shouldn't use a divert target (to {}) as a conditional value. Did you intend a function call 'likeThis()' or a read count check 'likeThis'? (no arrows)", target_path)));
                 }
 
@@ -123,19 +124,19 @@ mod misc {
 
         pub(crate) fn next_sequence_shuffle_index(&mut self) -> Result<i32, StoryError> {
             let pop_evaluation_stack = self.get_state_mut().pop_evaluation_stack();
-            let num_elements = if let Some(v) = Value::get_int_value(pop_evaluation_stack.as_ref())
-            {
-                v
-            } else {
-                return Err(StoryError::InvalidStoryState(
-                    "Expected number of elements in sequence for shuffle index".to_owned(),
-                ));
-            };
+            let num_elements =
+                if let Some(v) = Value::get_value::<i32>(pop_evaluation_stack.as_ref()) {
+                    v
+                } else {
+                    return Err(StoryError::InvalidStoryState(
+                        "Expected number of elements in sequence for shuffle index".to_owned(),
+                    ));
+                };
 
             let seq_container = self.get_state().get_current_pointer().container.unwrap();
 
             let seq_count = if let Some(v) =
-                Value::get_int_value(self.get_state_mut().pop_evaluation_stack().as_ref())
+                Value::get_value::<i32>(self.get_state_mut().pop_evaluation_stack().as_ref())
             {
                 v
             } else {

--- a/lib/src/story/progress.rs
+++ b/lib/src/story/progress.rs
@@ -9,6 +9,7 @@ use crate::{
     story::{errors::ErrorType, OutputStateChange, Story},
     story_error::StoryError,
     value::Value,
+    value_type::VariablePointerValue,
     void::Void,
 };
 use std::{self, rc::Rc};
@@ -443,8 +444,9 @@ impl Story {
             // to our current (possibly temporary) context index. And make a
             // copy of the pointer
             // so that we're not editing the original runtime Object.
-            let var_pointer =
-                Value::get_variable_pointer_value(current_content_obj.as_ref().unwrap().as_ref());
+            let var_pointer = Value::get_value::<&VariablePointerValue>(
+                current_content_obj.as_ref().unwrap().as_ref(),
+            );
 
             if let Some(var_pointer) = var_pointer {
                 if var_pointer.context_index == -1 {

--- a/lib/src/story/tags.rs
+++ b/lib/src/story/tags.rs
@@ -5,6 +5,7 @@ use crate::{
     story::Story,
     story_error::StoryError,
     value::Value,
+    value_type::StringValue,
 };
 
 /// # Tags
@@ -54,7 +55,9 @@ impl Story {
                 },
                 _ => {
                     if in_tag {
-                        if let Some(string_value) = Value::get_string_value(content.as_ref()) {
+                        if let Some(string_value) =
+                            Value::get_value::<&StringValue>(content.as_ref())
+                        {
                             tags.push(string_value.string.clone());
                         } else {
                             return Err(

--- a/lib/src/story_state.rs
+++ b/lib/src/story_state.rs
@@ -7,6 +7,7 @@ use crate::{
     control_command::{CommandType, ControlCommand},
     flow::Flow,
     glue::Glue,
+    ink_list::InkList,
     json::{json_read, json_write},
     list_definitions_origin::ListDefinitionsOrigin,
     object::{Object, RTObject},
@@ -496,10 +497,10 @@ impl StoryState {
 
         if head_first_newline_idx != -1 {
             if head_first_newline_idx > 0 {
-                let leading_spaces = Value::new_string(&text[0..head_first_newline_idx as usize]);
+                let leading_spaces = Value::new::<&str>(&text[0..head_first_newline_idx as usize]);
                 list_texts.push(leading_spaces);
             }
-            list_texts.push(Value::new_string("\n"));
+            list_texts.push(Value::new::<&str>("\n"));
             inner_str_start = head_last_newline_idx + 1;
         }
 
@@ -509,14 +510,14 @@ impl StoryState {
 
         if inner_str_end > inner_str_start as usize {
             let inner_str_text = &text[inner_str_start as usize..inner_str_end];
-            list_texts.push(Value::new_string(inner_str_text));
+            list_texts.push(Value::new::<&str>(inner_str_text));
         }
 
         if tail_last_newline_idx != -1 && tail_first_newline_idx > head_last_newline_idx {
-            list_texts.push(Value::new_string("\n"));
+            list_texts.push(Value::new::<&str>("\n"));
             if tail_last_newline_idx < text.len() as i32 - 1 {
                 let num_spaces = (text.len() as i32 - tail_last_newline_idx) - 1;
-                let trailing_spaces = Value::new_string(
+                let trailing_spaces = Value::new::<&str>(
                     &text[(tail_last_newline_idx + 1) as usize
                         ..(num_spaces + tail_last_newline_idx + 1) as usize],
                 );
@@ -1019,11 +1020,11 @@ impl StoryState {
         if let Some(arguments) = arguments {
             for arg in arguments {
                 let value = match arg {
-                    ValueType::Bool(v) => Value::new_bool(*v),
-                    ValueType::Int(v) => Value::new_int(*v),
-                    ValueType::Float(v) => Value::new_float(*v),
-                    ValueType::List(v) => Value::new_list(v.clone()),
-                    ValueType::String(v) => Value::new_string(&v.string),
+                    ValueType::Bool(v) => Value::new::<bool>(*v),
+                    ValueType::Int(v) => Value::new::<i32>(*v),
+                    ValueType::Float(v) => Value::new::<f32>(*v),
+                    ValueType::List(v) => Value::new::<InkList>(v.clone()),
+                    ValueType::String(v) => Value::new::<&str>(&v.string),
                     _ => {
                         return Err(StoryError::InvalidStoryState("ink arguments when calling EvaluateFunction / ChoosePathStringWithParameters must be \
                         int, float, string, bool or InkList.".to_owned()));
@@ -1088,7 +1089,7 @@ impl StoryState {
                 // DivertTargets get returned as the string of components
                 // (rather than a Path, which isn't public)
                 if let ValueType::DivertTarget(p) = &return_val.value {
-                    return Ok(Some(ValueType::new_string(&p.to_string())));
+                    return Ok(Some(ValueType::new::<&str>(&p.to_string())));
                 }
 
                 // Other types can just have their exact object type:

--- a/lib/src/variables_state.rs
+++ b/lib/src/variables_state.rs
@@ -198,7 +198,7 @@ impl VariablesState {
             )));
         }
 
-        let val = Value::from_value_type(value_type);
+        let val = Value::new_value_type(value_type);
 
         let notify = self.set_global(variable_name, Rc::new(val));
 

--- a/lib/src/variables_state.rs
+++ b/lib/src/variables_state.rs
@@ -115,7 +115,7 @@ impl VariablesState {
         let mut value = value;
         // Constructing new variable pointer reference
         if var_ass.is_new_declaration {
-            if let Some(var_pointer) = Value::get_variable_pointer_value(value.as_ref()) {
+            if let Some(var_pointer) = Value::get_value::<&VariablePointerValue>(value.as_ref()) {
                 value = self.resolve_variable_pointer(var_pointer);
             }
         } else {
@@ -127,7 +127,7 @@ impl VariablesState {
 
                 match existing_pointer {
                     Some(existing_pointer) => {
-                        match Value::get_variable_pointer_value(existing_pointer.as_ref()) {
+                        match Value::get_value::<&VariablePointerValue>(existing_pointer.as_ref()) {
                             Some(pv) => {
                                 name = pv.variable_name.to_string();
                                 context_index = pv.context_index;
@@ -178,7 +178,7 @@ impl VariablesState {
         // create
         // a chain of indirection by just returning the final target.
         if let Some(value_of_variable_pointed_to) = value_of_variable_pointed_to {
-            if Value::get_variable_pointer_value(value_of_variable_pointed_to.as_ref()).is_some() {
+            if Value::get_value::<&VariablePointerValue>(value_of_variable_pointed_to.as_ref()).is_some() {
                 return value_of_variable_pointed_to;
             }
         }
@@ -320,7 +320,7 @@ impl VariablesState {
         let var_value = self.get_raw_variable_with_name(name, context_index);
         // Get value from pointer?
         if let Some(vv) = var_value.clone() {
-            if let Some(var_pointer) = Value::get_variable_pointer_value(vv.as_ref()) {
+            if let Some(var_pointer) = Value::get_value::<&VariablePointerValue>(vv.as_ref()) {
                 return self.value_at_variable_pointer(var_pointer);
             }
         }

--- a/lib/src/variables_state.rs
+++ b/lib/src/variables_state.rs
@@ -178,7 +178,9 @@ impl VariablesState {
         // create
         // a chain of indirection by just returning the final target.
         if let Some(value_of_variable_pointed_to) = value_of_variable_pointed_to {
-            if Value::get_value::<&VariablePointerValue>(value_of_variable_pointed_to.as_ref()).is_some() {
+            if Value::get_value::<&VariablePointerValue>(value_of_variable_pointed_to.as_ref())
+                .is_some()
+            {
                 return value_of_variable_pointed_to;
             }
         }

--- a/lib/tests/function_test.rs
+++ b/lib/tests/function_test.rs
@@ -123,7 +123,7 @@ fn evaluating_function_variable_state_bug_test() -> Result<(), StoryError> {
     let mut output = String::new();
     let result = story.evaluate_function("function_to_evaluate", None, &mut output);
 
-    assert_eq!("RIGHT", result?.unwrap().get_str().unwrap());
+    assert_eq!("RIGHT", result?.unwrap().get::<&str>().unwrap());
 
     assert_eq!("End\n", story.cont()?);
 

--- a/lib/tests/runtime_test.rs
+++ b/lib/tests/runtime_test.rs
@@ -26,13 +26,13 @@ impl ExternalFunction for ExtFunc1 {
 
 impl ExternalFunction for ExtFunc2 {
     fn call(&mut self, _: &str, _: Vec<ValueType>) -> Option<ValueType> {
-        Some(ValueType::new_string("Hello world"))
+        Some(ValueType::new::<&str>("Hello world"))
     }
 }
 
 impl ExternalFunction for ExtFunc3 {
     fn call(&mut self, _: &str, args: Vec<ValueType>) -> Option<ValueType> {
-        Some(ValueType::Bool(args[0].get_int().unwrap() != 1))
+        Some(ValueType::Bool(args[0].get::<i32>().unwrap() != 1))
     }
 }
 
@@ -159,11 +159,11 @@ fn set_and_get_variable_test() -> Result<(), Box<dyn Error>> {
     let mut text: Vec<String> = Vec::new();
 
     common::next_all(&mut story, &mut text)?;
-    assert_eq!(10, story.get_variable("x").unwrap().get_int().unwrap());
+    assert_eq!(10, story.get_variable("x").unwrap().get::<i32>().unwrap());
 
     story.set_variable("x", &ValueType::Int(15))?;
 
-    assert_eq!(15, story.get_variable("x").unwrap().get_int().unwrap());
+    assert_eq!(15, story.get_variable("x").unwrap().get::<i32>().unwrap());
 
     story.choose_choice_index(0)?;
 
@@ -184,14 +184,14 @@ fn set_non_existant_variable_test() -> Result<(), Box<dyn Error>> {
 
     common::next_all(&mut story, &mut text)?;
 
-    let result = story.set_variable("y", &ValueType::new_string("earth"));
+    let result = story.set_variable("y", &ValueType::new::<&str>("earth"));
     assert!(result.is_err());
 
-    assert_eq!(10, story.get_variable("x").unwrap().get_int().unwrap());
+    assert_eq!(10, story.get_variable("x").unwrap().get::<i32>().unwrap());
 
     story.set_variable("x", &ValueType::Int(15))?;
 
-    assert_eq!(15, story.get_variable("x").unwrap().get_int().unwrap());
+    assert_eq!(15, story.get_variable("x").unwrap().get::<i32>().unwrap());
 
     story.choose_choice_index(0)?;
 


### PR DESCRIPTION
Replaces a number of methods on `Value` and `ValueType` with names like `get_foo_value` and `new_foo` into a single `get` and `new` method generic over `TryInto<foo>`.
With the stylistic change from different methods to generics, comes auto-generated `Value` constructors from `ValueType` constructors rather than declaring them all manually, but the main reason is I think it's a bit cleaner to use Rust's built-in traits.